### PR TITLE
[MOB-2957] Quick fix for the cancel dialog

### DIFF
--- a/uisdk/src/main/java/com/karhoo/uisdk/screen/trip/bookingstatus/contact/ContactOptionsView.kt
+++ b/uisdk/src/main/java/com/karhoo/uisdk/screen/trip/bookingstatus/contact/ContactOptionsView.kt
@@ -37,7 +37,7 @@ class ContactOptionsView @JvmOverloads constructor(
     }
 
     override fun showCancelConfirmationDialog() {
-        cancellationDialog = AlertDialog.Builder(context, R.style.AlertDialog)
+        cancellationDialog = AlertDialog.Builder(context, R.style.DialogTheme)
                 .setTitle(R.string.cancel_your_ride)
                 .setMessage(R.string.cancellation_fee)
                 .setPositiveButton(R.string.cancel) { _, _ -> presenter.cancelTrip() }
@@ -46,7 +46,7 @@ class ContactOptionsView @JvmOverloads constructor(
     }
 
     override fun showTripCancelledDialog() {
-        AlertDialog.Builder(context, R.style.AlertDialog)
+        AlertDialog.Builder(context, R.style.DialogTheme)
                 .setTitle(R.string.cancel_ride_successful)
                 .setMessage(R.string.cancel_ride_successful_message)
                 .setPositiveButton(R.string.ok) { _, _ -> actions?.goToCleanBooking() }
@@ -54,7 +54,7 @@ class ContactOptionsView @JvmOverloads constructor(
     }
 
     override fun showCallToCancelDialog(number: String, supplier: String) {
-        AlertDialog.Builder(context, R.style.AlertDialog)
+        AlertDialog.Builder(context, R.style.DialogTheme)
                 .setTitle(R.string.difficulties_cancelling_title)
                 .setMessage(R.string.difficulties_cancelling_message)
                 .setPositiveButton(R.string.call) { _, _ -> makeCall(number) }


### PR DESCRIPTION
AlertDialog style uses Theme.AppCompat.Light.Dialog.Alert which doesn't seem to work as intended at the moment.

## JIRA
[MOB-2957](https://karhoo.atlassian.net/browse/MOB-2957)

## DESCRIPTION
Found out the issue was not the AlertDialog itself but the theme of AlertDialog which it used, switched it to the DialogTheme now. From what I can tell the AppCompat Alert style seems to be a bit broken when it comes to compatibility with MaterialComponents.

## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [x] Bugfix 
- [ ] New feature 
- [ ] Tech Debt
- [ ] Breaking change 
- [ ] Documentation Update
- [ ] Other: *define what type of change it is*

## CHECKLIST

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging code._
Please review the guidelines for contributing to this repository.

- [x] All work relating to the ticket is complete (Code complete/Acceptance Criteria met)
- [x] Lint and unit tests pass locally (if appropriate)
- [ ] Added tests that prove the fix is effective or that feature works (if appropriate)
- [ ] Documentation (if appropriate)

## SCREENSHOTS
[Add screenshots if any for changes you have made to the App/UI]
