### PR TITLE
MOB-4650 fix drop in configuration

### DIFF
--- a/uisdk/src/adyen/java/com/karhoo/uisdk/AdyenPaymentPresenter.kt
+++ b/uisdk/src/adyen/java/com/karhoo/uisdk/AdyenPaymentPresenter.kt
@@ -71,7 +71,7 @@ class AdyenPaymentPresenter(
             }
         }
 
-    override fun getDropInConfig(context: Context, sdkToken: String): Any {
+    override fun getDropInConfig(context: Context, sdkToken: String, allowToSaveCard: Boolean): Any {
         val amount = Amount()
         amount.currency = quote?.price?.currencyCode ?: DEFAULT_CURRENCY
         amount.value = quote?.price?.highPrice.orZero()
@@ -104,7 +104,7 @@ class AdyenPaymentPresenter(
             .setEnvironment(environment)
             .addGooglePayConfiguration(googlePayConfig)
             .setShopperLocale(Locale.getDefault())
-            .addCardConfiguration(createCardConfig(context.applicationContext, key))
+            .addCardConfiguration(createCardConfig(context.applicationContext, key, allowToSaveCard))
             .build()
     }
 
@@ -252,7 +252,7 @@ class AdyenPaymentPresenter(
         this.passengerDetails = passengerDetails
     }
 
-    private fun createCardConfig(context: Context, publicKey: String): CardConfiguration {
+    private fun createCardConfig(context: Context, publicKey: String, allowToSaveCard: Boolean): CardConfiguration {
         val environment = if (KarhooUISDKConfigurationProvider.configuration.environment() is
                     KarhooEnvironment.Production
         ) {
@@ -265,7 +265,7 @@ class AdyenPaymentPresenter(
             .setShopperLocale(Locale.getDefault())
             .setHolderNameRequired(true)
             .setEnvironment(environment)
-            .setShowStorePaymentField(!KarhooUISDKConfigurationProvider.isGuest())
+            .setShowStorePaymentField(allowToSaveCard)
             .build()
     }
 

--- a/uisdk/src/adyen/java/com/karhoo/uisdk/AdyenPaymentView.kt
+++ b/uisdk/src/adyen/java/com/karhoo/uisdk/AdyenPaymentView.kt
@@ -9,6 +9,7 @@ import com.adyen.checkout.dropin.DropInConfiguration
 import com.karhoo.sdk.api.KarhooError
 import com.karhoo.sdk.api.model.Quote
 import com.karhoo.sdk.api.network.request.PassengerDetails
+import com.karhoo.uisdk.KarhooUISDKConfigurationProvider
 import com.karhoo.uisdk.R
 import com.karhoo.uisdk.screen.booking.checkout.payment.PaymentDropInContract
 import org.json.JSONObject
@@ -56,7 +57,8 @@ class AdyenPaymentView : PaymentDropInContract.View {
         val paymentMethods = PaymentMethodsApiResponse.SERIALIZER.deserialize(payments)
 
         try {
-            val dropInConfiguration: DropInConfiguration = presenter?.getDropInConfig(context, sdkToken) as DropInConfiguration
+            val allowToSaveCard = !KarhooUISDKConfigurationProvider.isGuest()
+            val dropInConfiguration: DropInConfiguration = presenter?.getDropInConfig(context, sdkToken, allowToSaveCard) as DropInConfiguration
 
             cacheSupplyPartnerId(context, quote)
 

--- a/uisdk/src/braintree/java/BraintreePaymentPresenter.kt
+++ b/uisdk/src/braintree/java/BraintreePaymentPresenter.kt
@@ -58,11 +58,19 @@ class BraintreePaymentPresenter(
         )
     }
 
-    override fun getDropInConfig(context: Context, sdkToken: String): Any {
+    override fun getDropInConfig(
+        context: Context,
+        sdkToken: String,
+        allowToSaveCard: Boolean
+    ): Any {
         return DropInRequest().apply {
-            vaultCardDefaultValue = true
-            isVaultManagerEnabled = true
-            allowVaultCardOverride = true
+            if (allowToSaveCard) {
+                vaultCardDefaultValue = true
+                allowVaultCardOverride = true
+            } else {
+                vaultCardDefaultValue = false
+                allowVaultCardOverride = false
+            }
             cardholderNameStatus = FIELD_REQUIRED
         }
     }

--- a/uisdk/src/braintree/java/BraintreePaymentView.kt
+++ b/uisdk/src/braintree/java/BraintreePaymentView.kt
@@ -23,7 +23,7 @@ class BraintreePaymentView : PaymentDropInContract.View {
     override fun handleThreeDSecure(context: Context, sdkToken: String, nonce: String, amount: String) {
         actions?.showLoadingButton(true)
 
-        val dropInRequest: DropInRequest = presenter?.getDropInConfig(context, sdkToken) as
+        val dropInRequest: DropInRequest = presenter?.getDropInConfig(context, sdkToken, true) as
                 DropInRequest
         val threeDSecureRequest = ThreeDSecureRequest().apply {
             this.nonce = nonce
@@ -59,7 +59,7 @@ class BraintreePaymentView : PaymentDropInContract.View {
     override fun showPaymentDropInUI(context: Context, sdkToken: String, paymentData: String?, quote: Quote?) {
         actions?.showLoadingButton(true)
 
-        val dropInRequest: DropInRequest = presenter?.getDropInConfig(context, sdkToken) as
+        val dropInRequest: DropInRequest = presenter?.getDropInConfig(context, sdkToken, false) as
                 DropInRequest
         val threeDSecureRequest = ThreeDSecureRequest().apply {
             this.amount = presenter?.quotePriceToAmount(quote)

--- a/uisdk/src/main/java/com/karhoo/uisdk/screen/booking/checkout/payment/PaymentDropInContract.kt
+++ b/uisdk/src/main/java/com/karhoo/uisdk/screen/booking/checkout/payment/PaymentDropInContract.kt
@@ -42,7 +42,7 @@ interface PaymentDropInContract {
 
         fun sdkInit(quote: Quote?, locale: Locale? = null)
 
-        fun getDropInConfig(context: Context, sdkToken: String): Any
+        fun getDropInConfig(context: Context, sdkToken: String, allowToSaveCard: Boolean): Any
 
         fun logPaymentFailureEvent(refusalReason: String, refusalReasonCode: Int = 0, lastFourDigits: String? = null, quoteId: String? = null)
 


### PR DESCRIPTION
## JIRA
[MOB-4650](https://karhoo.atlassian.net/browse/MOB-4650)

## Types of changes
In this ticket I changed 3 things:
-  added 'allowToSaveCard' params to 'getDropInConfig' method. Without this checkbox "Save for my next payment" was present also in Guest mode (naming for this parameter is aligned with iOS)
 - I changed 'vaultCardDefaultValue' to false for guest in Braintree, we don't want to save card for guest
 - I removed 'vaultCardDefaultValue = true". When this flag was set to true then user was able to remove card and it should be possible in our SDK (worst case scenario: user will book ride for future, then remove card and Karhoo will not be able to receive money when ride done)




## CHECKLIST
- [ ] 'Save card" checkbox should be visible only for authorised user
- [ ] Same behaviour for Adyen
- [ ] User should not be able to remove card


[MOB-4650]: https://karhoo.atlassian.net/browse/MOB-4650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ